### PR TITLE
Don't provision master until after workers

### DIFF
--- a/instances.tf
+++ b/instances.tf
@@ -131,7 +131,8 @@ resource "aws_instance" "icpmaster" {
     "aws_s3_bucket_object.bootstrap",
     "aws_s3_bucket_object.create_client_cert",
     "aws_s3_bucket_object.functions",
-    "aws_s3_bucket_object.start_install"
+    "aws_s3_bucket_object.start_install",
+    "aws_instance.icpnodes"
   ]
 
   count         = "${var.master["nodes"]}"


### PR DESCRIPTION
I ran into an issue where I hit a resource limit on my worker instance types and before that was resolved, the master was already trying to do work -- it was failing bc of the missing hosts file, but the point is the master shouldn't even provision until after the other nodes are there. It might be worth considering placing a dependency on some of these instances.

There may need to be a larger discussion on the topic, but I believe this is a start.