### PR TITLE
add lifecycle to avoid forcing new vms

### DIFF
--- a/instances.tf
+++ b/instances.tf
@@ -122,10 +122,7 @@ EOF
     # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
     # (eg, https://github.com/terraform-providers/terraform-provider-aws/issues/2036)
     # we have to ignore changes in the following arguments
-    ignore_changes = [
-      root_block_device,
-      ebs_block_device,
-    ]
+    ignore_changes = [ "root_block_device", "ebs_block_device" ]
   }
 }
 
@@ -217,13 +214,10 @@ users:
 EOF
 
   lifecycle {
-  # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
-  # (eg, https://github.com/terraform-providers/terraform-provider-aws/issues/2036)
-  # we have to ignore changes in the following arguments
-    ignore_changes = [
-      root_block_device,
-      ebs_block_device,
-    ]
+    # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
+    # (eg, https://github.com/terraform-providers/terraform-provider-aws/issues/2036)
+    # we have to ignore changes in the following arguments
+    ignore_changes = [ "root_block_device", "ebs_block_device" ]
   }
 }
 
@@ -295,10 +289,7 @@ EOF
     # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
     # (eg, https://github.com/terraform-providers/terraform-provider-aws/issues/2036)
     # we have to ignore changes in the following arguments
-    ignore_changes = [
-      root_block_device,
-      ebs_block_device,
-    ]
+    ignore_changes = [ "root_block_device", "ebs_block_device" ]
   }
 }
 
@@ -368,10 +359,7 @@ EOF
     # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
     # (eg, https://github.com/terraform-providers/terraform-provider-aws/issues/2036)
     # we have to ignore changes in the following arguments
-    ignore_changes = [
-      root_block_device,
-      ebs_block_device,
-    ]
+    ignore_changes = [ "root_block_device", "ebs_block_device" ]
   }
 }
 
@@ -442,10 +430,7 @@ EOF
     # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
     # (eg, https://github.com/terraform-providers/terraform-provider-aws/issues/2036)
     # we have to ignore changes in the following arguments
-    ignore_changes = [
-      root_block_device,
-      ebs_block_device,
-    ]
+    ignore_changes = [ "root_block_device", "ebs_block_device" ]
   }
 }
 
@@ -518,10 +503,7 @@ EOF
     # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
     # (eg, https://github.com/terraform-providers/terraform-provider-aws/issues/2036)
     # we have to ignore changes in the following arguments
-    ignore_changes = [
-      root_block_device,
-      ebs_block_device,
-    ]
+    ignore_changes = [ "root_block_device", "ebs_block_device" ]
   }
 }
 

--- a/instances.tf
+++ b/instances.tf
@@ -117,6 +117,16 @@ users:
   ssh-authorized-keys:
   - ${tls_private_key.installkey.public_key_openssh}
 EOF
+
+  lifecycle {
+    # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
+    # (eg, https://github.com/terraform-providers/terraform-provider-aws/issues/2036)
+    # we have to ignore changes in the following arguments
+    ignore_changes = [
+      root_block_device,
+      ebs_block_device,
+    ]
+  }
 }
 
 resource "aws_instance" "icpmaster" {
@@ -205,6 +215,16 @@ users:
   ssh-authorized-keys:
   - ${tls_private_key.installkey.public_key_openssh}
 EOF
+
+  lifecycle {
+  # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
+  # (eg, https://github.com/terraform-providers/terraform-provider-aws/issues/2036)
+  # we have to ignore changes in the following arguments
+    ignore_changes = [
+      root_block_device,
+      ebs_block_device,
+    ]
+  }
 }
 
 resource "aws_instance" "icpproxy" {
@@ -271,6 +291,15 @@ users:
   ssh-authorized-keys:
   - ${tls_private_key.installkey.public_key_openssh}
 EOF
+  lifecycle {
+    # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
+    # (eg, https://github.com/terraform-providers/terraform-provider-aws/issues/2036)
+    # we have to ignore changes in the following arguments
+    ignore_changes = [
+      root_block_device,
+      ebs_block_device,
+    ]
+  }
 }
 
 resource "aws_instance" "icpmanagement" {
@@ -335,6 +364,15 @@ users:
   ssh-authorized-keys:
   - ${tls_private_key.installkey.public_key_openssh}
 EOF
+  lifecycle {
+    # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
+    # (eg, https://github.com/terraform-providers/terraform-provider-aws/issues/2036)
+    # we have to ignore changes in the following arguments
+    ignore_changes = [
+      root_block_device,
+      ebs_block_device,
+    ]
+  }
 }
 
 resource "aws_instance" "icpva" {
@@ -400,6 +438,15 @@ users:
   - ${tls_private_key.installkey.public_key_openssh}
 EOF
 
+  lifecycle {
+    # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
+    # (eg, https://github.com/terraform-providers/terraform-provider-aws/issues/2036)
+    # we have to ignore changes in the following arguments
+    ignore_changes = [
+      root_block_device,
+      ebs_block_device,
+    ]
+  }
 }
 
 resource "aws_instance" "icpnodes" {
@@ -466,6 +513,16 @@ users:
   ssh-authorized-keys:
   - ${tls_private_key.installkey.public_key_openssh}
 EOF
+
+  lifecycle {
+    # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
+    # (eg, https://github.com/terraform-providers/terraform-provider-aws/issues/2036)
+    # we have to ignore changes in the following arguments
+    ignore_changes = [
+      root_block_device,
+      ebs_block_device,
+    ]
+  }
 }
 
 output "bootmaster" {


### PR DESCRIPTION
Currently when doing a plan/apply on existing cluster the AWS provider might force rebuilding of nodes with something like
```hcl
.aws_instance.icpnodes[2] (new resource required)
      id:                                                "i-0c3ef0428115d26cb" => <computed> (forces new resource)
      ami:                                               "ami-0cbf7a0c36bde57c9" => "ami-0cbf7a0c36bde57c9"
      arn:                                               "arn:aws:ec2:eu-west-1:675801125365:instance/i-0c3ef0428115d26cb" => <computed>
      associate_public_ip_address:                       "false" => <computed>
      availability_zone:                                 "eu-west-1c" => "eu-west-1c"
      cpu_core_count:                                    "4" => <computed>
      cpu_threads_per_core:                              "2" => <computed>
      ebs_block_device.#:                                "2" => "1"
      ebs_block_device.3042545595.delete_on_termination: "false" => "false"
      ebs_block_device.3042545595.device_name:           "/dev/xvdbc" => "" (forces new resource)
```

as per https://github.com/terraform-providers/terraform-provider-aws/issues/2036 ignore ebs_block_device to fix this